### PR TITLE
Use portable path construction

### DIFF
--- a/src/motivating_functions.jl
+++ b/src/motivating_functions.jl
@@ -81,7 +81,7 @@ end
 function loadquotes_mot(;cate::Union{String,Array}=[],types::String="motivate")
 
     # Load the list of (de-)motivational quotes (get path where the module is on the current system. It comes with the module file name which we need to remove and chop 3 additional characters off because of the ".jl"-ending.)
-    read_path = chop(pathof(MotivateMe),tail=length(string(@__MODULE__))+3)*"\\data\\mot_quotes.csv"
+    read_path = joinpath(@__DIR__, "data", "mot_quotes.csv")
     quote_df = CSV.read(read_path, DataFrame;header = true)
 
     # Select quotes of a specific category and type


### PR DESCRIPTION
A neat tools for locating files relative to the current file are `@__DIR__` and `@__FILE__`, and we can use `joinpath` for a cross-platform way of constructing paths relative to that directory.

With this patch, the package works on Linux (and theoretically Mac as well)

```
help?> @__DIR__
  @__DIR__ -> String

  Expand to a string with the absolute path to the directory of the file
  containing the macrocall. Return the current working directory if run from a
  REPL or if evaluated by julia -e <expr>.

help?> joinpath
search: joinpath

  joinpath(parts::AbstractString...) -> String
  joinpath(parts::Vector{AbstractString}) -> String
  joinpath(parts::Tuple{AbstractString}) -> String

  Join path components into a full path. If some argument is an absolute path
  or (on Windows) has a drive specification that doesn't match the drive
  computed for the join of the preceding paths, then prior components are
  dropped.

  Note on Windows since there is a current directory for each drive,
  joinpath("c:", "foo") represents a path relative to the current directory on
  drive "c:" so this is equal to "c:foo", not "c:\foo". Furthermore, joinpath
  treats this as a non-absolute path and ignores the drive letter casing,
  hence joinpath("C:\A","c:b") = "C:\A\b".

  Examples
  ≡≡≡≡≡≡≡≡

  julia> joinpath("/home/myuser", "example.jl")
  "/home/myuser/example.jl"

  julia> joinpath(["/home/myuser", "example.jl"])
  "/home/myuser/example.jl"
```